### PR TITLE
Fix Typescript validation error for react client

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./react": "./dist/react"
+    "./react": "./dist/react.js"
   },
   "typings": "dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
Fix export of react file. Without this fix `tsc` would output the following error:

```
src/main.tsx:2:34 - error TS2307: Cannot find module '@databorg/client/react' or its corresponding type declarations.

2 import { DataborgProvider } from '@databorg/client/react';
```